### PR TITLE
Add Android App Links support

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,9 +745,22 @@ If you have a custom domain (e.g. `links.yourcompany.com`), add another intent f
 </intent-filter>
 ```
 
-**Step 2: Handle App Links in your Activity**
+**Step 2: Set launch mode on your Activity**
 
-No additional code changes needed — `handleInsertLink()` already handles both custom URL schemes and `https://` App Links automatically.
+Add `android:launchMode="singleTop"` to your main activity to prevent it being recreated when an App Link is tapped while the app is already running:
+
+```xml
+<activity
+    android:name=".MainActivity"
+    android:launchMode="singleTop"
+    ...>
+```
+
+This ensures `onNewIntent()` is called instead of creating a new activity instance. Without this, the activity will "flash" and reload, potentially losing the deep link data.
+
+**Step 3: Handle App Links in your Activity**
+
+No additional code changes needed — `handleInsertLink()` already handles both custom URL schemes and `https://` App Links automatically. Just make sure you call it from both `onCreate()` and `onNewIntent()`.
 
 **Testing App Links:**
 

--- a/README.md
+++ b/README.md
@@ -705,6 +705,59 @@ I/InsertAffiliate TAG: [Insert Affiliate] Short link received: AFFILIATE1
 I/InsertAffiliate TAG: [Insert Affiliate] Storing affiliate identifier: AFFILIATE1
 ```
 
+#### Android App Links (Optional, Recommended)
+
+Android App Links provide a better user experience than custom URL schemes. When a user taps an Insert Link and already has your app installed, Android opens the app directly — without loading the browser or showing a disambiguation dialog.
+
+**Prerequisites:**
+- Enter your **Android Bundle Identifier** (package name) and **SHA-256 Certificate Fingerprints** in the Insert Affiliate dashboard settings
+
+**To find your SHA-256 fingerprint:**
+```bash
+# For debug builds
+keytool -list -v -keystore ~/.android/debug.keystore -alias androiddebugkey -storepass android -keypass android | grep SHA256
+
+# For release builds (use your keystore)
+keytool -list -v -keystore your-release-key.keystore -alias your-alias | grep SHA256
+```
+
+**Step 1: Add intent filter to AndroidManifest.xml**
+
+Add this inside your main `<activity>` tag:
+
+```xml
+<intent-filter android:autoVerify="true">
+    <action android:name="android.intent.action.VIEW" />
+    <category android:name="android.intent.category.DEFAULT" />
+    <category android:name="android.intent.category.BROWSABLE" />
+    <data android:scheme="https" android:host="insertaffiliate.link" />
+</intent-filter>
+```
+
+If you have a custom domain (e.g. `links.yourcompany.com`), add another intent filter:
+
+```xml
+<intent-filter android:autoVerify="true">
+    <action android:name="android.intent.action.VIEW" />
+    <category android:name="android.intent.category.DEFAULT" />
+    <category android:name="android.intent.category.BROWSABLE" />
+    <data android:scheme="https" android:host="links.yourcompany.com" />
+</intent-filter>
+```
+
+**Step 2: Handle App Links in your Activity**
+
+No additional code changes needed — `handleInsertLink()` already handles both custom URL schemes and `https://` App Links automatically.
+
+**Testing App Links:**
+
+```bash
+# Via ADB
+adb shell am start -a android.intent.action.VIEW -d "https://insertaffiliate.link/YOUR_COMPANY_CODE/TEST_SHORT_CODE"
+```
+
+> **Note:** App Links verification requires the app to be signed with the certificate matching the fingerprint in the dashboard. Debug builds use a different certificate than release builds — add both fingerprints if testing in debug mode.
+
 ✅ **Insert Links setup complete!** Skip to [Verify Your Integration](#-verify-your-integration)
 
 </details>

--- a/app/src/main/java/com/aks/insertaffiliateandroid/InsertAffiliateManager.java
+++ b/app/src/main/java/com/aks/insertaffiliateandroid/InsertAffiliateManager.java
@@ -51,7 +51,8 @@ public class InsertAffiliateManager {
         DEEP_LINK_ANDROID("deep_link_android"),      // Android deep link with ?insertAffiliate= param
         INSTALL_REFERRER("install_referrer"),        // Android Play Store install referrer
         SHORT_CODE_MANUAL("short_code_manual"),      // Developer called setShortCode()
-        REFERRING_LINK("referring_link");            // Developer called setInsertAffiliateIdentifier()
+        REFERRING_LINK("referring_link"),            // Developer called setInsertAffiliateIdentifier()
+        APP_LINK("app_link");                       // Android App Link (https://insertaffiliate.link/companycode/shortcode)
 
         private final String value;
 
@@ -1179,7 +1180,7 @@ public class InsertAffiliateManager {
     }
 
     /**
-     * Handles deep links containing insertAffiliate parameter
+     * Handles deep links containing insertAffiliate parameter and App Links (https:// URLs)
      * This method should be called from Activity.onCreate() and Activity.onNewIntent()
      * @param activity The activity context
      * @param intent The intent containing the deep link data
@@ -1189,13 +1190,20 @@ public class InsertAffiliateManager {
             verboseLog("No intent or URI data found in handleInsertLink");
             return;
         }
-        
+
         Uri uri = intent.getData();
         verboseLog("InsertAffiliate: Processing Insert Link URI: " + uri.toString());
-        
-        // Look for insertAffiliate parameter in the URI
+
+        // Handle App Links (https:// URLs from insertaffiliate.link or custom domains)
+        String scheme = uri.getScheme();
+        if ("https".equals(scheme) || "http".equals(scheme)) {
+            handleAppLink(activity, uri);
+            return;
+        }
+
+        // Handle custom URL scheme deep links with insertAffiliate query parameter
         String insertAffiliate = uri.getQueryParameter("insertAffiliate");
-        
+
         if (insertAffiliate != null && !insertAffiliate.isEmpty()) {
             verboseLog("Found insertAffiliate parameter: " + insertAffiliate);
             Log.i("InsertAffiliate TAG", "[Insert Affiliate] Deep link detected with insertAffiliate parameter: " + insertAffiliate);
@@ -1205,6 +1213,45 @@ public class InsertAffiliateManager {
         } else {
             verboseLog("No insertAffiliate parameter found in deep link");
         }
+    }
+
+    /**
+     * Handles Android App Links (https:// URLs)
+     * Supports formats:
+     *   - https://insertaffiliate.link/companyCode/shortCode
+     *   - https://insertaffiliate.link/V1/companyCode/shortCode (legacy)
+     *   - https://customdomain.com/companyCode/shortCode
+     * @param activity The activity context
+     * @param uri The App Link URI
+     */
+    private static void handleAppLink(Activity activity, Uri uri) {
+        List<String> pathSegments = uri.getPathSegments();
+
+        String urlCompanyCode;
+        String shortCode;
+
+        if (pathSegments.size() >= 3 && "V1".equals(pathSegments.get(0))) {
+            // Legacy format: /V1/companyCode/shortCode
+            urlCompanyCode = pathSegments.get(1);
+            shortCode = pathSegments.get(2);
+        } else if (pathSegments.size() >= 2) {
+            // Current format: /companyCode/shortCode
+            urlCompanyCode = pathSegments.get(0);
+            shortCode = pathSegments.get(1);
+        } else {
+            verboseLog("Invalid App Link format: " + uri.toString());
+            return;
+        }
+
+        verboseLog("App Link detected - Company: " + urlCompanyCode + ", Short code: " + shortCode);
+        Log.i("InsertAffiliate TAG", "[Insert Affiliate] App Link detected - Company: " + urlCompanyCode + ", Short code: " + shortCode);
+
+        // Validate company code matches initialized one
+        if (companyCode != null && !urlCompanyCode.equalsIgnoreCase(companyCode)) {
+            verboseLog("Warning: URL company code (" + urlCompanyCode + ") doesn't match initialized company code (" + companyCode + ")");
+        }
+
+        storeInsertAffiliateReferringLink(activity, shortCode.toUpperCase(), AffiliateAssociationSource.APP_LINK);
     }
 
     /**

--- a/app/src/main/java/com/aks/insertaffiliateandroid/InsertAffiliateManager.java
+++ b/app/src/main/java/com/aks/insertaffiliateandroid/InsertAffiliateManager.java
@@ -25,6 +25,7 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 


### PR DESCRIPTION
## Summary
- Add `APP_LINK` source type for Android App Links
- Update `handleInsertLink` to detect and route `https://` URLs to new `handleAppLink` method
- Support both `/companyCode/shortCode` and legacy `/V1/` formats
- Update README with AndroidManifest intent filters, `singleTop` launch mode, SHA-256 fingerprint instructions

## Test plan
- [x] Tested on Samsung device with `insertaffiliate.link` domain
- [x] Tested with custom domain `test-custom.insertaffiliate.com`
- [x] Google Digital Asset Links verification passing